### PR TITLE
Update for Django 1.8

### DIFF
--- a/shortener/urls.py
+++ b/shortener/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except:
+    # Django <=1.5
+    from django.conf.urls.defaults import patterns, url
 
 
 urlpatterns = patterns('shortener.views',

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
   </head>
 
   <body>
-      <h1><a href="{% url index %}">{{ request.META.HTTP_HOST }}</a></h1>
+      <h1><a href="{% url 'index' %}">{{ request.META.HTTP_HOST }}</a></h1>
       <hr/>
       {% block content %}{% endblock %}
 
@@ -15,7 +15,7 @@
       {% block bookmarklet %}
       <br/>
       Bookmarklet (drag this to your bookmarks bar):<br/>
-      <a href="javascript:(function(){var a=window,b=document,c=encodeURIComponent;d=a.open(&#39;//{{ request.META.HTTP_HOST }}/submit/?u=&#39;+c(b.location));})();">Shorten with {{ request.META.HTTP_HOST }}</a>
+      <a href="javascript:(function(){var a=window,b=document,c=encodeURIComponent;d=a.open(&#39;//{{ request.META.HTTP_HOST }}{% url 'index' %}submit/?u=&#39;+c(b.location));})();">Shorten with {{ request.META.HTTP_HOST }}</a>
       {% endblock %}
 
     {% block extra_body %}{% endblock %}

--- a/templates/shortener/form.inc.html
+++ b/templates/shortener/form.inc.html
@@ -1,5 +1,5 @@
 {% if link_form %}
-  <form name="url_form" action="{% url submit %}" method="post">
+  <form name="url_form" action="{% url 'submit' %}" method="post">
     {% csrf_token %}
     {{ link_form.as_p }}
     <input type="submit" value="Shorten" />

--- a/templates/shortener/index.html
+++ b/templates/shortener/index.html
@@ -6,7 +6,7 @@
 <ul>
   {% for link in recent_links %}
     <li><a href="{% short_url link %}">{{ link.url }}</a> (Count: {{ link.usage_count }})
-    (<a href="{% url info link.to_base62 %}">Info</a>)</li>
+    (<a href="{% url 'info' link.to_base62 %}">Info</a>)</li>
   {% endfor %}
 </ul>
 
@@ -14,7 +14,7 @@
 <ul>
   {% for link in most_popular_links %}
     <li><a href="{% short_url link %}">{{ link.url }}</a> (Count: {{ link.usage_count }})
-    (<a href="{% url info link.to_base62 %}">Info</a>)</li>
+    (<a href="{% url 'info' link.to_base62 %}">Info</a>)</li>
   {% endfor %}
 </ul>
 {% endblock content %}


### PR DESCRIPTION
Update urls.py, url template tag for Django 1.8.
Bookmarklet: don't assume shortener app is at URL root (e.g. support /shortener/).